### PR TITLE
Add allTime interval to ensure all data is shown on charts

### DIFF
--- a/common/types.tsx
+++ b/common/types.tsx
@@ -79,3 +79,11 @@ export interface GroupedDataByRegionAndData {
   "South America": { incoming: number; outgoing: number };
   Uncategorized: { incoming: number; outgoing: number };
 }
+
+export enum graphIntervalsEnum  {
+  oneMonth = "month",
+  threeMonths = "3month",
+  sixMonths = "6month",
+  twelveMonths = "12month",
+  allTime = "allTime;"
+}

--- a/common/utilities.ts
+++ b/common/utilities.ts
@@ -1,3 +1,5 @@
+import { graphIntervalsEnum } from "./types";
+
 const hasOwn = {}.hasOwnProperty;
 const protocolAndDomainRE = /^(?:\w+:)?\/\/(\S+)$/;
 const localhostDomainRE = /^localhost[\:?\d]*(?:[^\:?\d]\S*)?$/;
@@ -208,13 +210,13 @@ export function changeIntervalToCurrentDate(interval) {
   const currentDate = new Date();
 
   switch (interval) {
-    case "month":
+    case graphIntervalsEnum.oneMonth:
       return currentDate.setMonth(currentDate.getMonth() - 1);
-    case "3month":
+    case graphIntervalsEnum.threeMonths:
       return currentDate.setMonth(currentDate.getMonth() - 3);
-    case "6month":
+    case graphIntervalsEnum.sixMonths:
       return currentDate.setMonth(currentDate.getMonth() - 6);
-    case "allTime":
+    case graphIntervalsEnum.allTime:
       return new Date('2023')
   }
 

--- a/common/utilities.ts
+++ b/common/utilities.ts
@@ -214,6 +214,8 @@ export function changeIntervalToCurrentDate(interval) {
       return currentDate.setMonth(currentDate.getMonth() - 3);
     case "6month":
       return currentDate.setMonth(currentDate.getMonth() - 6);
+    case "allTime":
+      return new Date('2023')
   }
 
   //check if the current interval currentDate touches the previous years

--- a/components/SectionGraphByIndustry.tsx
+++ b/components/SectionGraphByIndustry.tsx
@@ -4,6 +4,7 @@ import {
   updateClientIndustry,
 } from "@root/resolvers/client-industry";
 import { IndustryStackedBarChart } from "./IndustryStackedBarChart";
+import { graphIntervalsEnum } from "@root/common/types";
 import { AllData } from "@root/common/types";
 import { useState } from "react";
 import FilterSelection from "./FilterSelection";
@@ -12,9 +13,7 @@ import { IndustryChartTimeFilter } from "./IndustryChartTimeFilter";
 
 export default function SectionGraphByIndustry({ allData }) {
   if (!allData) return;
-  const [selectedInterval, setSelectedInterval] = useState<
-    "month" | "3month" | "6month" | "12month" | "allTime"
-  >("allTime");
+  const [selectedInterval, setSelectedInterval] = useState<graphIntervalsEnum>(graphIntervalsEnum.allTime);
   const breakpoint = useBreakpoint();
   const isMobile =
     breakpoint === BreakpointEnum.XS || breakpoint === BreakpointEnum.SM;
@@ -39,19 +38,19 @@ export default function SectionGraphByIndustry({ allData }) {
   const options = [
     {
       text: "30D",
-      value: "month",
+      value: graphIntervalsEnum.oneMonth,
     },
     {
       text: "90D",
-      value: "3month",
+      value: graphIntervalsEnum.threeMonths,
     },
     {
       text: "180D",
-      value: "6month",
+      value: graphIntervalsEnum.sixMonths,
     },
     {
-      text: "All Time",
-      value: "allTime",
+      text: "All time",
+      value: graphIntervalsEnum.allTime,
     },
   ];
 

--- a/components/SectionGraphByIndustry.tsx
+++ b/components/SectionGraphByIndustry.tsx
@@ -13,8 +13,8 @@ import { IndustryChartTimeFilter } from "./IndustryChartTimeFilter";
 export default function SectionGraphByIndustry({ allData }) {
   if (!allData) return;
   const [selectedInterval, setSelectedInterval] = useState<
-    "month" | "3month" | "6month" | "12month"
-  >("6month");
+    "month" | "3month" | "6month" | "12month" | "allTime"
+  >("allTime");
   const breakpoint = useBreakpoint();
   const isMobile =
     breakpoint === BreakpointEnum.XS || breakpoint === BreakpointEnum.SM;
@@ -48,6 +48,10 @@ export default function SectionGraphByIndustry({ allData }) {
     {
       text: "180D",
       value: "6month",
+    },
+    {
+      text: "All Time",
+      value: "allTime",
     },
   ];
 

--- a/components/SectionGraphByRegion.tsx
+++ b/components/SectionGraphByRegion.tsx
@@ -5,15 +5,14 @@ import {
   groupClientsByWeekAndRegion,
   updateClientRegions,
 } from "@root/resolvers/client-regions";
+import { graphIntervalsEnum } from "@root/common/types";
 import { useState } from "react";
 import FilterSelection from "./FilterSelection";
 import { BreakpointEnum, useBreakpoint } from "@root/common/use-breakpoint";
 import { RegionChartTimeFiltered } from "./RegionChartTimeFiltered";
 
 export default function SectionGraphByRegion({ allData }) {
-  const [selectedInterval, setSelectedInterval] = useState<
-    "month" | "3month" | "6month" | "12month" | "allTime"
-  >("allTime");
+  const [selectedInterval, setSelectedInterval] = useState<graphIntervalsEnum>(graphIntervalsEnum.allTime);
   const breakpoint = useBreakpoint();
   const isMobile =
     breakpoint === BreakpointEnum.XS || breakpoint === BreakpointEnum.SM;
@@ -39,19 +38,19 @@ export default function SectionGraphByRegion({ allData }) {
   const options = [
     {
       text: "30D",
-      value: "month",
+      value: graphIntervalsEnum.oneMonth,
     },
     {
       text: "90D",
-      value: "3month",
+      value: graphIntervalsEnum.threeMonths,
     },
     {
       text: "180D",
-      value: "6month",
+      value: graphIntervalsEnum.sixMonths,
     },
     {
-      text: "All Time",
-      value: "allTime",
+      text: "All time",
+      value: graphIntervalsEnum.allTime,
     },
   ];
   return (

--- a/components/SectionGraphByRegion.tsx
+++ b/components/SectionGraphByRegion.tsx
@@ -12,8 +12,8 @@ import { RegionChartTimeFiltered } from "./RegionChartTimeFiltered";
 
 export default function SectionGraphByRegion({ allData }) {
   const [selectedInterval, setSelectedInterval] = useState<
-    "month" | "3month" | "6month" | "12month"
-  >("6month");
+    "month" | "3month" | "6month" | "12month" | "allTime"
+  >("allTime");
   const breakpoint = useBreakpoint();
   const isMobile =
     breakpoint === BreakpointEnum.XS || breakpoint === BreakpointEnum.SM;
@@ -48,6 +48,10 @@ export default function SectionGraphByRegion({ allData }) {
     {
       text: "180D",
       value: "6month",
+    },
+    {
+      text: "All Time",
+      value: "allTime",
     },
   ];
   return (


### PR DESCRIPTION
## Description
The charts no longer show the data; this started approximately a week ago. Kenton (From filecoin) reported this bug; he mentioned that all the data was loading correctly a few weeks ago.
Upon inspection, I found that the data returned successfully from the DB but was not showing on the charts.

The data returned from the API starts from April 24, 2023 (week 17) to October 16, 2023 (week 42). What is happening is that the graph is now only showing data for 2024. Since Kenton said the data was showing fine a few weeks ago, my best guess is that last week being week 17 for 2024, it could have switched to only showing data in 2024.

<img width="1282" alt="Screenshot 2024-05-01 at 7 46 28 AM" src="https://github.com/application-research/filecoin-user-explorer/assets/56281168/97bd86a6-ba2f-407d-a01a-dc87d613ab5d">

## Changes
I have created an `All Time` interval filter to display the data and fix the issue. I also added an enum for the filterIntervals `graphIntervalsEnum`.